### PR TITLE
ormConfig cache ttl

### DIFF
--- a/src/GraphqlOrmDataSource.ts
+++ b/src/GraphqlOrmDataSource.ts
@@ -18,7 +18,11 @@ export class GraphqlOrmDataSource<TContext = any> extends DataSource<TContext> {
     super();
     this.orm = ormConfig.orm;
     this.useCache = !! ormConfig.cache;
-    this.cacheTtl = ormConfig.cache?.milliseconds ?? 1000 * 30;
+    this.cacheTtl = Math.floor(
+      (ormConfig.cache?.milliseconds && ormConfig.cache.milliseconds / 1000) ??
+      ormConfig.cache?.seconds ??
+      1000 * 30
+    );
   }
 
   initialize(config: DataSourceConfig<TContext>): void {
@@ -60,7 +64,7 @@ export class GraphqlOrmDataSource<TContext = any> extends DataSource<TContext> {
 
   protected cacheSet(key: string, val: any): void {
     if (this.cache) {
-      const cacheStr = EJSON.stringify(val); 
+      const cacheStr = EJSON.stringify(val);
       this.cache.set(key, cacheStr, { ttl: this.cacheTtl });
     }
   }
@@ -89,7 +93,7 @@ export class GraphqlOrmDataSource<TContext = any> extends DataSource<TContext> {
     const repo = this.repo<TEntity>(target);
     const repoName = typeof repo;
     let data: Array<TEntity | undefined> = [];
-    
+
     if (this.cache) {
       let key: string;
       const idsNotFound: any[] = [];
@@ -112,7 +116,7 @@ export class GraphqlOrmDataSource<TContext = any> extends DataSource<TContext> {
       const rows = await repo.findByIds(ids, options);
       data = rows;
     }
-    
+
     return Promise.resolve(data);
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ import { Connection } from 'typeorm';
 
 export interface CacheOptions {
   milliseconds: number;
+  seconds: number;
 };
 
 export interface GraphqlOrmDataSourceConfig {


### PR DESCRIPTION
When trying to configure the datasource to cache results for a day (in milliseconds: 8.64e7), it instead caches the result for ~33 months:

- In ormConfig.cache, divide milliseconds value by 1000 if defined, rounding down (Apollo in-memory cache uses seconds rather than milliseconds for ttl)
- Add `seconds` to `CacheOptions` interface
- Use either `milliseconds` or `seconds` for setting datasource instance `cacheTtl`.